### PR TITLE
Remove cwp require from composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,5 @@
     "silverstripe",
     "cwp"
   ],
-  "license": "BSD-3-Clause",
-  "require": {
-    "cwp/cwp": "^1.9"
-  }
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
Requiring cwp module might prevent the use of this module in projects using cwp-recipes